### PR TITLE
ESPHome 2026.5 compatibility: ClimateTraits feature flags + heartbeat-timeout underflow fix

### DIFF
--- a/esphome/components/espar_can/espar_can.cpp
+++ b/esphome/components/espar_can/espar_can.cpp
@@ -66,10 +66,14 @@ void EsparCanComponent::setup() {
 void EsparCanComponent::loop() {
   if (!driver_installed_) return;
 
-  uint32_t now = millis();
-
   // ── RX: process incoming heater frames ──────────────────────────────
   handle_rx_();
+
+  // Capture 'now' AFTER handle_rx_(): note_heater_alive_() sets
+  // heater_last_seen_ = millis() while draining RX, so sampling 'now' before
+  // that lets (now - heater_last_seen_) underflow (uint32) and spuriously trip
+  // the heartbeat timeout — the cause of connect/disconnect flapping.
+  uint32_t now = millis();
 
   // ── Init burst retry until heater acks ──────────────────────────────
   if (!heater_connected_ && (now - t_init_last_) >= INIT_RESEND_MS) {

--- a/esphome/components/espar_can/espar_can.cpp
+++ b/esphome/components/espar_can/espar_can.cpp
@@ -139,13 +139,14 @@ void EsparCanComponent::loop() {
 
 climate::ClimateTraits EsparCanComponent::traits() {
   auto traits = climate::ClimateTraits();
-  traits.set_supports_current_temperature(true);
+  // ESPHome 2026.x replaced the set_supports_* booleans with feature flags.
+  traits.add_feature_flags(climate::CLIMATE_SUPPORTS_CURRENT_TEMPERATURE |
+                           climate::CLIMATE_SUPPORTS_ACTION);
   traits.set_supported_modes({
       climate::CLIMATE_MODE_OFF,
       climate::CLIMATE_MODE_HEAT,
       climate::CLIMATE_MODE_FAN_ONLY,
   });
-  traits.set_supports_action(true);
   traits.set_visual_min_temperature(15.0f);   // 59°F
   traits.set_visual_max_temperature(30.0f);   // 86°F
   traits.set_visual_temperature_step(0.5f);


### PR DESCRIPTION
Two independent bug fixes, both present on main. No behavior or feature changes: build-fix and correctness only.

1) ClimateTraits API break (build failure on ESPHome 2026.5+): traits() called set_supports_current_temperature() and set_supports_action(), both removed in ESPHome 2026.5. Migrated to the feature-flag API: add_feature_flags(CLIMATE_SUPPORTS_CURRENT_TEMPERATURE | CLIMATE_SUPPORTS_ACTION). Fixes #12

2) Heartbeat-timeout uint32 underflow (connection flapping): loop() sampled now = millis() before handle_rx_(), which sets heater_last_seen_ = millis() (>= now). The timeout check now - heater_last_seen_ then underflowed and tripped a spurious "Heartbeat lost" whenever handle_rx_() crossed a millisecond boundary, causing espar_connected/fault to flap and the LED to strobe. Fixed by sampling now after handle_rx_(). Fixes #11

Testing: compiles and flashes cleanly on ESPHome 2026.5.3 (ESP32, Arduino framework); on hardware the heater connects and enters HEATING, and with the underflow fix the connection latches stably instead of flapping.

Split from test/connected-liveness-oem-frames (which also carries the 0x2C4-liveness and OEM-frame changes, still under test) so these two bug fixes can land on main independently.